### PR TITLE
Fix CI

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,9 +6,6 @@
  * See the file LICENSES/README.md for more information.
  */
 
-/* eslint @typescript-eslint/ban-ts-comment: "off" */
-// @ts-ignore
-
 /**
  * You need to export an object to set up your config. Go to
  * https://hardhat.org/config/ to learn more.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "jsx": "react-jsx",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",


### PR DESCRIPTION
## Description

Reverts the change made in https://github.com/peak3d/wolves.finance/commit/5591d7d13201bce641e4fb0170f61d0afaf56479#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0 that breaks CI.

Setting isolated modules to true breaks the compilation of typescript in the root folder, required for configuring the solidity compiler versions.

Unfortunately, React overwrites this value every time it's run. @peak3d do you know of any way to disable this behavior? Otherwise we'll have to take care to not this change again.

## How has this been tested?

See green CI results.